### PR TITLE
test(runtime): close prisma pool in teardown to prevent open handles

### DIFF
--- a/src/config/prisma.ts
+++ b/src/config/prisma.ts
@@ -1,27 +1,38 @@
 const { PrismaClient } = require("@prisma/client");
 const { PrismaPg } = require("@prisma/adapter-pg");
 const { Pool } = require("pg");
+
 const path = process.env.NODE_ENV === "test" ? "tests/.env.test" : ".env";
 require("dotenv").config({ path, override: false });
 
-/**
- * PostgreSQL connection pool.
- * Explicit pool management is required in Prisma 7.
- */
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-});
+const globalForPrisma = globalThis;
 
-/**
- * Prisma Client singleton.
- *
- * - Uses pg driver explicitly (Prisma 7+)
- * - Avoids multiple connections
- * - Centralizes database access
- */
-const prisma = new PrismaClient({
-  adapter: new PrismaPg(pool),
-  log: ["error", "warn"],
-});
+if (!globalForPrisma.__authApiPool) {
+  globalForPrisma.__authApiPool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+  });
+}
+
+if (!globalForPrisma.__authApiPrisma) {
+  globalForPrisma.__authApiPrisma = new PrismaClient({
+    adapter: new PrismaPg(globalForPrisma.__authApiPool),
+    log: ["error", "warn"],
+  });
+}
+
+const pool = globalForPrisma.__authApiPool;
+const prisma = globalForPrisma.__authApiPrisma;
+
+let isClosing = false;
+async function closePrismaConnection() {
+  if (isClosing) return;
+  isClosing = true;
+
+  await prisma.$disconnect();
+  await pool.end();
+
+  isClosing = false;
+}
 
 module.exports = prisma;
+module.exports.closePrismaConnection = closePrismaConnection;

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,5 @@
 const prisma = require("../src/config/prisma.ts");
+const { closePrismaConnection } = require("../src/config/prisma.ts");
 const { closeRedisConnection } = require("../src/config/redis.ts");
 
 beforeEach(async () => {
@@ -8,5 +9,5 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await closeRedisConnection();
-  await prisma.$disconnect();
+  await closePrismaConnection();
 });


### PR DESCRIPTION
## Resumo
- fortalece o teardown de testes para evitar recursos assíncronos pendentes ao final da suíte
- centraliza o encerramento do Prisma/Pool em utilitário explícito de cleanup
- reduz ruído local de execução relacionado a encerramento do Jest

## O que mudou
- `src/config/prisma.ts`
  - adiciona gerenciamento explícito de fechamento (`closePrismaConnection`)
  - garante encerramento de `prisma.$disconnect()` e `pool.end()`
- `tests/setup.js`
  - passa a usar `closePrismaConnection()` no `afterAll`, junto com `closeRedisConnection()`

## Validação
- `npm run lint`
- `npm run test:coverage:jest`
- `npx jest --config jest.config.cjs --runInBand --coverage --detectOpenHandles --openHandlesTimeout=5000`

## Resultado
- suítes e testes passando
- cobertura mantida
- execução com `--detectOpenHandles` sem apontar handle pendente no cenário validado
