### PR TITLE
chore(test): reduce test runtime log noise (dotenv, pino, prisma)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 const express = require("express");
-require("dotenv").config();
+require("dotenv").config({ quiet: true });
 
 const app = express();
 app.use(express.json());

--- a/src/config/prisma.ts
+++ b/src/config/prisma.ts
@@ -3,8 +3,9 @@ const { PrismaPg } = require("@prisma/adapter-pg");
 const { Pool } = require("pg");
 
 const path = process.env.NODE_ENV === "test" ? "tests/.env.test" : ".env";
-require("dotenv").config({ path, override: false });
+require("dotenv").config({ path, override: false, quiet: true });
 
+const prismaLog = process.env.NODE_ENV === "test" ? [] : ["error", "warn"];
 const globalForPrisma = globalThis;
 
 if (!globalForPrisma.__authApiPool) {
@@ -16,7 +17,7 @@ if (!globalForPrisma.__authApiPool) {
 if (!globalForPrisma.__authApiPrisma) {
   globalForPrisma.__authApiPrisma = new PrismaClient({
     adapter: new PrismaPg(globalForPrisma.__authApiPool),
-    log: ["error", "warn"],
+    log: prismaLog,
   });
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,8 +1,9 @@
 const pino = require("pino");
 
+const isTestEnv = process.env.NODE_ENV === "test";
 // Logger base: JSON, nível info por padrão
 const logger = pino({
-  level: process.env.LOG_LEVEL || "info",
+  level: process.env.LOG_LEVEL || (isTestEnv ? "silent" : "info"),
   transport:
     process.env.NODE_ENV === "development"
       ? {

--- a/tests/jest.env.js
+++ b/tests/jest.env.js
@@ -1,4 +1,5 @@
 // Carrega variáveis de teste a partir do arquivo correto (dentro de tests/)
 require("dotenv").config({
   path: "tests/.env.test",
+  quiet: true,
 });


### PR DESCRIPTION
## Resumo
- reduz ruído de logs em ambiente de teste
- aplica `quiet: true` no carregamento de env (`app`, `prisma` e setup de testes)
- configura logger base para `silent` quando `NODE_ENV=test`
- desativa logs do Prisma em teste (`log: []`), mantendo `error/warn` fora de teste

## Motivação
- melhorar legibilidade dos logs no CI/local
- facilitar detecção de falhas reais sem ruído operacional
- manter comportamento de produção inalterado

## Validação
- `npm run lint`
- `npm run test:coverage:jest`
- `npx jest --config jest.config.cjs --runInBand --coverage --detectOpenHandles --openHandlesTimeout=5000 2>&1 | tee /tmp/jest-noise.log`
- `grep -nE "\\[dotenv@|\"msg\":\"http_request\"|prisma:error|Jest did not exit|open handles|DEP0169|localstorage-file" /tmp/jest-noise.log || echo "Sem ruído relevante."`

## Resultado
- 13/13 suítes passando
- 90/90 testes passando
- cobertura global mantida (98.93% / branches 88.88%)
- sem ruído relevante no log consolidado de teste
