### PR TITLE
test(middleware): increase branch coverage for validate and error handler

### DIFF
--- a/tests/middleware/errorHandler.middleware.test.ts
+++ b/tests/middleware/errorHandler.middleware.test.ts
@@ -55,4 +55,15 @@ describe("errorHandler middleware", () => {
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     expect(res.status).toHaveBeenCalledWith(500);
   });
+  it("usa APP_ERROR quando AppError vem sem code", () => {
+    const res = createRes();
+
+    errorHandler(new AppError("conflito", 409, ""), {}, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "conflito",
+      code: "APP_ERROR",
+    });
+  });
 });

--- a/tests/middleware/validate.middleware.test.ts
+++ b/tests/middleware/validate.middleware.test.ts
@@ -1,0 +1,58 @@
+const validate = require("../../src/middlewares/validate.ts");
+
+describe("validate middleware", () => {
+  it("segue com payload normalizado quando schema é válido", () => {
+    const req = { body: { email: "TEST@MAIL.COM" } };
+    const next = vi.fn();
+
+    const schema = {
+      safeParse: vi.fn(() => ({
+        success: true,
+        data: { email: "test@mail.com" },
+      })),
+    };
+
+    validate(schema)(req, {}, next);
+
+    expect(req.body).toEqual({ email: "test@mail.com" });
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("retorna INVALID_PAYLOAD com mensagens agregadas", () => {
+    const req = { body: { email: "" } };
+    const next = vi.fn();
+
+    const schema = {
+      safeParse: vi.fn(() => ({
+        success: false,
+        error: { issues: [{ message: "email inválido" }, { message: "senha curta" }] },
+      })),
+    };
+
+    validate(schema)(req, {}, next);
+
+    const err = next.mock.calls[0][0];
+    expect(err.message).toBe("email inválido; senha curta");
+    expect(err.statusCode).toBe(400);
+    expect(err.code).toBe("INVALID_PAYLOAD");
+  });
+
+  it('usa fallback "invalid payload" quando não há issues', () => {
+    const req = { body: {} };
+    const next = vi.fn();
+
+    const schema = {
+      safeParse: vi.fn(() => ({
+        success: false,
+        error: { issues: [] },
+      })),
+    };
+
+    validate(schema)(req, {}, next);
+
+    const err = next.mock.calls[0][0];
+    expect(err.message).toBe("invalid payload");
+    expect(err.statusCode).toBe(400);
+    expect(err.code).toBe("INVALID_PAYLOAD");
+  });
+});


### PR DESCRIPTION
## Resumo
- adiciona testes para `src/middlewares/validate.ts`, cobrindo:
  - fluxo de sucesso com payload normalizado
  - fluxo de erro com mensagens agregadas
  - fallback de mensagem `"invalid payload"` quando não há issues
- adiciona cenário no `errorHandler` para `AppError` sem `code`, validando fallback para `"APP_ERROR"`

## Motivação
- aumentar branch coverage nos middlewares
- garantir comportamento explícito dos fallbacks de erro
- reduzir risco de regressão em validação e serialização de erros

## Validação
- `npx jest --config jest.config.cjs --runInBand tests/middleware/validate.middleware.test.ts tests/middleware/errorHandler.middleware.test.ts`
- `npm run lint`
- `npm run test:coverage:jest`

## Resultado
- 16/16 suítes passando
- 101/101 testes passando
- cobertura global: 99.20%
- branch coverage global: 96.03%
- `validate.ts`: 100% branches
- `errorHandler.ts`: 100% branches
