### PR TITLE
fix: restore release smoke validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,9 +177,6 @@ jobs:
     timeout-minutes: 30
     environment:
       name: ${{ needs.resolve-context.outputs.github_environment }}
-    outputs:
-      app_base_url: ${{ steps.validate-config.outputs.app_base_url }}
-      railway_environment: ${{ steps.validate-config.outputs.railway_environment }}
     env:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
@@ -229,11 +226,6 @@ jobs:
             esac
           fi
 
-          {
-            echo "app_base_url=${APP_BASE_URL:-}"
-            echo "railway_environment=${RAILWAY_ENVIRONMENT}"
-          } >> "${GITHUB_OUTPUT}"
-
       - name: Checkout source
         uses: actions/checkout@v6
         with:
@@ -259,11 +251,13 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment:
+      name: ${{ needs.resolve-context.outputs.github_environment }}
     env:
       DEPLOY_REF: ${{ needs.resolve-context.outputs.ref }}
       GITHUB_ENVIRONMENT_NAME: ${{ needs.resolve-context.outputs.github_environment }}
-      RAILWAY_ENVIRONMENT: ${{ needs.deploy.outputs.railway_environment }}
-      APP_BASE_URL: ${{ needs.deploy.outputs.app_base_url }}
+      RAILWAY_ENVIRONMENT: ${{ secrets.RAILWAY_ENVIRONMENT || needs.resolve-context.outputs.railway_environment }}
+      APP_BASE_URL: ${{ needs.resolve-context.outputs.requested_base_url != '' && needs.resolve-context.outputs.requested_base_url || secrets.RAILWAY_PUBLIC_URL }}
       SMOKE_REQUIRED: ${{ needs.resolve-context.outputs.smoke_required }}
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-api",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.3.0",
@@ -1457,7 +1457,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
@@ -2488,7 +2488,7 @@
       }
     },
     "node_modules/ee-first": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
@@ -2557,7 +2557,7 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
@@ -3867,7 +3867,7 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Production-grade authentication API with session governance, refresh rotation, Prisma/PostgreSQL persistence, Redis rate limiting, and contract-driven documentation.",
   "main": "dist/src/server.js",
   "type": "commonjs",

--- a/src/contracts/authContract.ts
+++ b/src/contracts/authContract.ts
@@ -141,7 +141,7 @@ export const openApiSpec = {
   openapi: "3.0.3",
   info: {
     title: "Auth API",
-    version: "1.1.1",
+    version: "1.1.2",
     description:
       "Production-grade authentication API with first-class sessions, refresh-token rotation, and contract-driven documentation.",
   },


### PR DESCRIPTION
## Summary

Restore the release-driven production validation path by resolving environment-scoped Railway secrets directly inside the post-deploy validation job.

## What changed

- bind the `validate deployment` job to the same GitHub Environment as the deploy job
- resolve `RAILWAY_ENVIRONMENT` and `RAILWAY_PUBLIC_URL` directly in the validation job instead of passing secret-derived values through job outputs
- remove now-unnecessary deploy job outputs for smoke configuration
- bump repository and OpenAPI version metadata to `1.1.2` for the next formal patch release

## Validation

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] workflow YAML parsed successfully with the local `yaml` package

## Risks/Notes

- this is a targeted workflow fix after `v1.1.1` exposed a secret-scoping issue in the release path
- the next formal release should be `v1.1.2`
