### PR TITLE
chore: prepare v1.1.3 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-api",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-api",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "ISC",
       "dependencies": {
         "@prisma/adapter-pg": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-api",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Production-grade authentication API with session governance, refresh rotation, Prisma/PostgreSQL persistence, Redis rate limiting, and contract-driven documentation.",
   "main": "dist/src/server.js",
   "type": "commonjs",

--- a/src/contracts/authContract.ts
+++ b/src/contracts/authContract.ts
@@ -141,7 +141,7 @@ export const openApiSpec = {
   openapi: "3.0.3",
   info: {
     title: "Auth API",
-    version: "1.1.2",
+    version: "1.1.3",
     description:
       "Production-grade authentication API with first-class sessions, refresh-token rotation, and contract-driven documentation.",
   },


### PR DESCRIPTION
## Summary

Prepare the next patch release after the runtime and deployment hardening landed on `main`.

## What changed

- bump the package version to `1.1.3`
- align the lockfile metadata to `1.1.3`
- align the OpenAPI contract version to `1.1.3`

## Validation

- [x] metadata-only change; behavioural validation is covered by the hardening PR already merged into `main`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run test:integration` when the change affects infrastructure-backed paths

## Risks/Notes

- This PR is intentionally limited to release metadata so the review and the release diff stay clean.
- The production promotion path will still re-verify the exact release ref before deploy.
